### PR TITLE
fix typo on default vsplit key binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Configure neomux by setting any of these variables in your `.vimrc` / `init.vim`
   keys start a new Neomux term in the current window.
 - `g:neomux_start_term_split_map` - Default: `<C-w>t`. This map controls what
   keys start a Neomux term in a `:split` window.
-- `g:neomux_start_term_vsplit_map` - Default: `<C-w>t`. This map controls what keys
+- `g:neomux_start_term_vsplit_map` - Default: `<C-w>T`. This map controls what keys
   start a Neomux term in a `:vsplit` window.
 - `g:neomux_winjump_map_prefix` - Default: `<C-w><win_num>`. In Neomux you
   can jump to any open window by hitting `<C-w><win_num>` (e.g. `<C-w>2` jumps to


### PR DESCRIPTION
The default key binding for open the neomux on `vsplit` is typed as `<C-w>t` instead `<C-w>T` on [key binding session](https://github.com/nikvdp/neomux/tree/4b78a630f186a1da63f1f19d20a014702e9e083f#key-bindings-1)