### PR TITLE
Config option to disable confirmation for `g:neomux_start_term_*map` keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,12 +343,18 @@ Configure neomux by setting any of these variables in your `.vimrc` / `init.vim`
   neovim's default `<C-\><C-n>`, you can disable it by setting
   `g:neomux_no_exit_term_map` to `1`.
 
-- `g:neomux_start_term_noconfirm` - By default neomux will confirm the commands
+- `g:neomux_hitenter_fix` - There is 
+  [an issue](https://github.com/neovim/neovim/issues/20380) when using 
+  `cmdheight=0` that causes hit-enter confirmations in neovim when any of the 
+  `g:neomux_start_term_*map` keys are executed. Until the issue is fixed, you
+  can work around it by setting `g:neomux_hitenter_fix` to `1`.
+
+- `g:neomux_hitenter_fix` - By default neomux will confirm the commands
   to run when any of the `g:neomux_start_term_*map` keys are executed
   ("Press ENTER or type command to continue"). If you don't want this
   confirmation and would rather these map keys just open the new terminal
   immediately, you can disable the confirmation by setting
-  `g:neomux_start_term_noconfirm` to `1`.
+  `g:neomux_hitenter_fix` to `1`.
 
 ### Miscellanea / troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,13 @@ Configure neomux by setting any of these variables in your `.vimrc` / `init.vim`
   neovim's default `<C-\><C-n>`, you can disable it by setting
   `g:neomux_no_exit_term_map` to `1`.
 
+- `g:neomux_start_term_noconfirm` - By default neomux will confirm the commands
+  to run when any of the `g:neomux_start_term_*map` keys are executed
+  ("Press ENTER or type command to continue"). If you don't want this
+  confirmation and would rather these map keys just open the new terminal
+  immediately, you can disable the confirmation by setting
+  `g:neomux_start_term_noconfirm` to `1`.
+
 ### Miscellanea / troubleshooting
 
 - If you want a simple way to send keys to a neomux terminal session you can do

--- a/doc/neomux.txt
+++ b/doc/neomux.txt
@@ -392,6 +392,13 @@ to configure your plugin manager to load neomux _after_ the airline plugin.**
   use neovim's default '<C-\><C-n>', you can disable it by setting
   'g:neomux_no_exit_term_map' to '1'.
 
+- '`g:neomux_start_term_noconfirm`' - By default neomux will confirm the commands
+  to run when any of the '`g:neomux_start_term_*map`' keys are executed
+  ("Press ENTER or type command to continue"). If you don't want this
+  confirmation and would rather these map keys just open the new terminal
+  immediately, you can disable the confirmation by setting
+  `'g:neomux_start_term_noconfirm`' to `1`.
+
 -------------------------------------------------------------------------------
                                            *neomux-miscellanea-troubleshooting*
 Miscellanea / troubleshooting ~

--- a/doc/neomux.txt
+++ b/doc/neomux.txt
@@ -392,12 +392,10 @@ to configure your plugin manager to load neomux _after_ the airline plugin.**
   use neovim's default '<C-\><C-n>', you can disable it by setting
   'g:neomux_no_exit_term_map' to '1'.
 
-- '`g:neomux_start_term_noconfirm`' - By default neomux will confirm the commands
-  to run when any of the '`g:neomux_start_term_*map`' keys are executed
-  ("Press ENTER or type command to continue"). If you don't want this
-  confirmation and would rather these map keys just open the new terminal
-  immediately, you can disable the confirmation by setting
-  `'g:neomux_start_term_noconfirm`' to `1`.
+- 'g:neomux_hitenter_fix' - There is an issue [10] when using 'cmdheight=0' that
+  causes hit-enter confirmations in neovim when any of the 
+  'g:neomux_start_term_*map' keys are executed. Until the issue is fixed, you
+  can work around it by setting 'g:neomux_hitenter_fix' to '1'.
 
 -------------------------------------------------------------------------------
                                            *neomux-miscellanea-troubleshooting*
@@ -426,5 +424,6 @@ References ~
 [7] https://nikvdp.com/images/neomux-3-registers.gif
 [8] https://www.brianstorti.com/vim-registers/
 [9] https://github.com/vim-airline/vim-airline
+[10] https://github.com/neovim/neovim/issues/20380
 
 vim: ft=help

--- a/plugin/neomux.vim
+++ b/plugin/neomux.vim
@@ -29,6 +29,7 @@ function! s:NeomuxMain()
     if !exists('g:neomux_start_term_map') | let g:neomux_start_term_map = '<Leader>sh' | endif
     if !exists('g:neomux_start_term_split_map') | let g:neomux_start_term_split_map = '<C-w>t' | endif
     if !exists('g:neomux_start_term_vsplit_map') | let g:neomux_start_term_vsplit_map = '<C-w>T' | endif
+    if !exists('g:neomux_start_term_noconfirm') | let g:neomux_start_term_noconfirm = 0 | endif
     if !exists('g:neomux_winjump_map_prefix') | let g:neomux_winjump_map_prefix = "<C-w>" | endif
     " neomux_enable_set_win_to_cur_pos is experimental, only enable if requested 
     if exists('g:neomux_enable_set_win_to_cur_pos')
@@ -77,8 +78,16 @@ function! s:NeomuxMain()
         execute printf('inoremap %s <Esc>', g:neomux_exit_term_mode_map)
     endif
 
+    " If g:neomux_start_term_noconfirm is set, use an extra <CR> to skip
+    " confirmation of term-start commands
+    if g:neomux_start_term_noconfirm == 0
+      let l:neomux_start_term_noconfirm_str = ''
+    else
+      let l:neomux_start_term_noconfirm_str = '<CR>'
+    endif
+
     " set neomux start term map
-    execute printf("noremap %s :Neomux<CR>", g:neomux_start_term_map)
+    execute printf("noremap %s :Neomux<CR>%s", g:neomux_start_term_map, l:neomux_start_term_noconfirm_str)
 
     " set winswap mappings
     for i in [1,2,3,4,5,6,7,8,9]
@@ -89,10 +98,10 @@ function! s:NeomuxMain()
         call EnableWinJump()
     endif
 
-    execute printf('noremap %s :split<CR>:call NeomuxTerm()<CR>', g:neomux_start_term_split_map)
-    execute printf('noremap %s :vsplit<CR>:call NeomuxTerm()<CR>', g:neomux_start_term_vsplit_map)
-    execute printf('tnoremap %s <C-\><C-n>:split<CR>:call NeomuxTerm()<CR>', g:neomux_start_term_split_map)
-    execute printf('tnoremap %s <C-\><C-n>:vsplit<CR>:call NeomuxTerm()<CR>', g:neomux_start_term_vsplit_map)
+    execute printf('noremap %s :split<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_split_map, l:neomux_start_term_noconfirm_str)
+    execute printf('noremap %s :vsplit<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_vsplit_map, l:neomux_start_term_noconfirm_str)
+    execute printf('tnoremap %s <C-\><C-n>:split<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_split_map, l:neomux_start_term_noconfirm_str)
+    execute printf('tnoremap %s <C-\><C-n>:vsplit<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_vsplit_map, l:neomux_start_term_noconfirm_str)
 
     " Yank current buffer
     execute printf('map %s :call NeomuxYankBuffer()<CR>', g:neomux_yank_buffer_map)

--- a/plugin/neomux.vim
+++ b/plugin/neomux.vim
@@ -29,7 +29,7 @@ function! s:NeomuxMain()
     if !exists('g:neomux_start_term_map') | let g:neomux_start_term_map = '<Leader>sh' | endif
     if !exists('g:neomux_start_term_split_map') | let g:neomux_start_term_split_map = '<C-w>t' | endif
     if !exists('g:neomux_start_term_vsplit_map') | let g:neomux_start_term_vsplit_map = '<C-w>T' | endif
-    if !exists('g:neomux_start_term_noconfirm') | let g:neomux_start_term_noconfirm = 0 | endif
+    if !exists('g:neomux_hitenter_fix') | let g:neomux_hitenter_fix = 0 | endif
     if !exists('g:neomux_winjump_map_prefix') | let g:neomux_winjump_map_prefix = "<C-w>" | endif
     " neomux_enable_set_win_to_cur_pos is experimental, only enable if requested 
     if exists('g:neomux_enable_set_win_to_cur_pos')
@@ -78,16 +78,16 @@ function! s:NeomuxMain()
         execute printf('inoremap %s <Esc>', g:neomux_exit_term_mode_map)
     endif
 
-    " If g:neomux_start_term_noconfirm is set, use an extra <CR> to skip
+    " If g:neomux_hitenter_fix is set, use an extra <CR> to skip
     " confirmation of term-start commands
-    if g:neomux_start_term_noconfirm == 0
-      let l:neomux_start_term_noconfirm_str = ''
+    if g:neomux_hitenter_fix == 0
+      let l:neomux_hitenter_fix_str = ''
     else
-      let l:neomux_start_term_noconfirm_str = '<CR>'
+      let l:neomux_hitenter_fix_str = '<CR>'
     endif
 
     " set neomux start term map
-    execute printf("noremap %s :Neomux<CR>%s", g:neomux_start_term_map, l:neomux_start_term_noconfirm_str)
+    execute printf("noremap %s :Neomux<CR>%s", g:neomux_start_term_map, l:neomux_hitenter_fix_str)
 
     " set winswap mappings
     for i in [1,2,3,4,5,6,7,8,9]
@@ -98,10 +98,10 @@ function! s:NeomuxMain()
         call EnableWinJump()
     endif
 
-    execute printf('noremap %s :split<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_split_map, l:neomux_start_term_noconfirm_str)
-    execute printf('noremap %s :vsplit<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_vsplit_map, l:neomux_start_term_noconfirm_str)
-    execute printf('tnoremap %s <C-\><C-n>:split<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_split_map, l:neomux_start_term_noconfirm_str)
-    execute printf('tnoremap %s <C-\><C-n>:vsplit<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_vsplit_map, l:neomux_start_term_noconfirm_str)
+    execute printf('noremap %s :split<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_split_map, l:neomux_hitenter_fix_str)
+    execute printf('noremap %s :vsplit<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_vsplit_map, l:neomux_hitenter_fix_str)
+    execute printf('tnoremap %s <C-\><C-n>:split<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_split_map, l:neomux_hitenter_fix_str)
+    execute printf('tnoremap %s <C-\><C-n>:vsplit<CR>:call NeomuxTerm()<CR>%s', g:neomux_start_term_vsplit_map, l:neomux_hitenter_fix_str)
 
     " Yank current buffer
     execute printf('map %s :call NeomuxYankBuffer()<CR>', g:neomux_yank_buffer_map)


### PR DESCRIPTION
I wanted the ability to just open a terminal rather than having to hit ENTER each time I used `C-w + [t,T]`:

<img width="856" alt="Screenshot 2023-04-01 at 9 49 04 AM" src="https://user-images.githubusercontent.com/498293/229305738-140089f6-afa4-420f-b4f3-41bf0da42ed8.png">

This PR adds a config option to enable skipping this confirmation by tacking an additional `<CR>` to the end of the commands run by those mapped keys.

Does this seem like a reasonable thing to upstream?